### PR TITLE
Add SortCommand and SortCommandParser

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.commands;public class SortCommand {
+}

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -1,2 +1,99 @@
-package seedu.address.logic.commands;public class SortCommand {
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Comparator;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Sorts and lists all persons in the address book by the specified criteria.
+ * The available sorting criteria are by name or by appointment.
+ */
+public class SortCommand extends Command {
+
+    public static final String COMMAND_WORD = "sort";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all persons by the specified criteria.\n"
+            + "Parameters: name | appointment\n"
+            + "Example: " + COMMAND_WORD + " name\n"
+            + "         " + COMMAND_WORD + " appointment\n";
+
+    public static final String MESSAGE_INVALID_SORTING_CRITERIA = "Invalid sorting criteria.\n";
+    public static final String MESSAGE_SORTED_BY_NAME = "Sorted by name.";
+    public static final String MESSAGE_SORTED_BY_APPOINTMENT = "Sorted by appointment.";
+
+    /**
+     * The available sorting criteria: sorting by name or by appointment.
+     */
+    public enum SortType {
+        NAME, APPOINTMENT
+    }
+
+    private final SortType sortType;
+
+    /**
+     * Creates a SortCommand to sort persons by the specified {@code SortType}.
+     *
+     * @param sortType The type of sorting to be applied (name or appointment).
+     */
+    public SortCommand(SortType sortType) {
+        this.sortType = sortType;
+    }
+
+    /**
+     * Executes the sort command and sorts the persons in the address book based on the specified criteria.
+     * If sorting by name, it sorts alphabetically. If sorting by appointment, it sorts chronologically
+     * while placing persons with no appointment at the bottom.
+     *
+     * @param model {@code Model} which contains the address book data.
+     * @return The result of the command execution.
+     * @throws CommandException if an invalid sorting criteria is specified.
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        String resultMessage;
+
+        switch (sortType) {
+        case NAME:
+            // Sort persons by name alphabetically
+            model.updateSortedPersonList(Comparator.comparing(person -> person.getName().toString()));
+            resultMessage = MESSAGE_SORTED_BY_NAME;
+            break;
+        case APPOINTMENT:
+            // Sort persons by appointment, placing null appointments at the bottom
+            model.updateSortedPersonList(Comparator.comparing(person ->
+                            person.getAppointment() == null ? null : person.getAppointment().value,
+                    Comparator.nullsLast(Comparator.naturalOrder())));
+            resultMessage = MESSAGE_SORTED_BY_APPOINTMENT;
+            break;
+        default:
+            throw new CommandException(MESSAGE_INVALID_SORTING_CRITERIA);
+        }
+
+        return new CommandResult(
+                String.format(resultMessage, model.getFilteredPersonList().size()));
+    }
+
+    /**
+     * Compares this SortCommand to another object to check for equality.
+     *
+     * @param other The object to compare to.
+     * @return True if both objects are of the same type and have the same {@code SortType}.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof SortCommand)) {
+            return false;
+        }
+
+        SortCommand otherSortCommand = (SortCommand) other;
+        return sortType == otherSortCommand.sortType;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RemarkCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -88,6 +89,9 @@ public class AddressBookParser {
 
         case ViewCommand.COMMAND_WORD:
             return new ViewCommandParser().parse(arguments);
+
+        case SortCommand.COMMAND_WORD:
+            return new SortCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.parser;public class SortCommandParser {
+}

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,2 +1,40 @@
-package seedu.address.logic.parser;public class SortCommandParser {
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new SortCommand object.
+ */
+public class SortCommandParser implements Parser<SortCommand> {
+
+    private static final String SORT_BY_NAME = "name";
+    private static final String SORT_BY_APPOINTMENT = "appointment";
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the SortCommand
+     * and returns a SortCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform to the expected format.
+     */
+    @Override
+    public SortCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        String[] splitArgs = trimmedArgs.split("\\s+");
+
+        if (splitArgs.length == 0) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        }
+
+        String sortType = splitArgs[0].toLowerCase();
+
+        return switch (sortType) {
+        case SORT_BY_NAME -> new SortCommand(SortCommand.SortType.NAME);
+        case SORT_BY_APPOINTMENT -> new SortCommand(SortCommand.SortType.APPOINTMENT);
+        default ->
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        };
+    }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,9 +1,11 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
 
@@ -11,7 +13,9 @@ import seedu.address.model.person.Person;
  * The API of the Model component.
  */
 public interface Model {
-    /** {@code Predicate} that always evaluate to true */
+    /**
+     * {@code Predicate} that always evaluate to true
+     */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 
     /**
@@ -49,7 +53,9 @@ public interface Model {
      */
     void setAddressBook(ReadOnlyAddressBook addressBook);
 
-    /** Returns the AddressBook */
+    /**
+     * Returns the AddressBook
+     */
     ReadOnlyAddressBook getAddressBook();
 
     /**
@@ -76,12 +82,19 @@ public interface Model {
      */
     void setPerson(Person target, Person editedPerson);
 
-    /** Returns an unmodifiable view of the filtered person list */
+    /**
+     * Returns an unmodifiable view of the filtered person list
+     */
     ObservableList<Person> getFilteredPersonList();
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
+     *
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    void updateSortedPersonList(Comparator<Person> comparator);
+
+    SortedList<Person> getSortedPersonList();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,11 +4,13 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
@@ -22,6 +24,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final SortedList<Person> sortedPersons;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -33,7 +36,8 @@ public class ModelManager implements Model {
 
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
-        filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        sortedPersons = new SortedList<>(this.addressBook.getPersonList());
+        filteredPersons = new FilteredList<>(sortedPersons);
     }
 
     public ModelManager() {
@@ -120,6 +124,23 @@ public class ModelManager implements Model {
     @Override
     public ObservableList<Person> getFilteredPersonList() {
         return filteredPersons;
+    }
+
+    @Override
+    public SortedList<Person> getSortedPersonList() {
+        return sortedPersons;
+    }
+
+    /**
+     * Updates the sorting order of the sorted persons list using the given comparator.
+     * The list will be sorted according to the comparator, which can be dynamically changed.
+     *
+     * @param comparator The comparator used to determine the new sort order.
+     */
+    @Override
+    public void updateSortedPersonList(Comparator<Person> comparator) {
+        requireNonNull(comparator);
+        sortedPersons.setComparator(comparator);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.Appointment;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Nric;
@@ -24,16 +25,16 @@ public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Nric("S1234567A"), new Address("Blk 30 Geylang Street 29, #06-40"), EMPTY_REMARK,
-                getTagSet("friends"), null),
+                new Nric("S1234567A"), new Address("Blk 30 Geylang Street 29', #06-40"), EMPTY_REMARK,
+                getTagSet("friends"), new Appointment("31-12-2024 00:00")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Nric("S1234567B"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), EMPTY_REMARK,
-                getTagSet("colleagues", "friends"), null),
+                getTagSet("colleagues", "friends"), new Appointment("30-12-2024 00:00")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Nric("S1234567C"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), EMPTY_REMARK,
-                getTagSet("neighbours"), null),
+                getTagSet("neighbours"), new Appointment("01-05-2025 13:22")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Nric("S1234567D"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), EMPTY_REMARK,

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -10,11 +10,13 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -155,6 +157,16 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public SortedList<Person> getSortedPersonList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateSortedPersonList(Comparator<Person> comparator) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.commands;public class SortCommandTest {
+}

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,2 +1,87 @@
-package seedu.address.logic.commands;public class SortCommandTest {
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.transformation.SortedList;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code SortCommand}.
+ */
+public class SortCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        SortCommand sortByNameCommand = new SortCommand(SortCommand.SortType.NAME);
+        SortCommand sortByAppointmentCommand = new SortCommand(SortCommand.SortType.APPOINTMENT);
+
+        // same object -> returns true
+        assertTrue(sortByNameCommand.equals(sortByNameCommand));
+
+        // same values -> returns true
+        SortCommand sortByNameCommandCopy = new SortCommand(SortCommand.SortType.NAME);
+        assertTrue(sortByNameCommand.equals(sortByNameCommandCopy));
+
+        // different types -> returns false
+        assertFalse(sortByNameCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(sortByNameCommand.equals(null));
+
+        // different sort type -> returns false
+        assertFalse(sortByNameCommand.equals(sortByAppointmentCommand));
+    }
+
+    @Test
+    public void execute_sortByName_success() throws Exception {
+        SortCommand sortByNameCommand = new SortCommand(SortCommand.SortType.NAME);
+        CommandResult result = sortByNameCommand.execute(model);
+
+        // Expected result message
+        assertEquals(SortCommand.MESSAGE_SORTED_BY_NAME, result.getFeedbackToUser());
+
+        // Verify that the list is sorted by name
+        SortedList<Person> actualSortedList = model.getSortedPersonList();
+        List<Person> expectedSortedList = model.getFilteredPersonList().stream()
+                .sorted(Comparator.comparing(person -> person.getName().toString()))
+                .collect(Collectors.toList());
+
+        // Assert that the actual sorted list matches the expected sorted list
+        assertEquals(expectedSortedList, actualSortedList);
+    }
+
+    @Test
+    public void execute_sortByAppointment_success() throws Exception {
+        SortCommand sortByAppointmentCommand = new SortCommand(SortCommand.SortType.APPOINTMENT);
+        CommandResult result = sortByAppointmentCommand.execute(model);
+
+        // Expected result message
+        assertEquals(SortCommand.MESSAGE_SORTED_BY_APPOINTMENT, result.getFeedbackToUser());
+
+        // Verify that the list is sorted by appointment
+        SortedList<Person> actualSortedList = model.getSortedPersonList();
+        List<Person> expectedSortedList = model.getFilteredPersonList().stream()
+                .sorted(Comparator.comparing(
+                        person -> person.getAppointment() == null ? null : person.getAppointment().value,
+                        Comparator.nullsLast(Comparator.naturalOrder())))
+                .collect(Collectors.toList());
+
+        // Assert that the actual sorted list matches the expected sorted list
+        assertEquals(expectedSortedList, actualSortedList);
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -24,6 +24,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RemarkCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -105,6 +106,17 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_view() throws Exception {
         assertTrue(parser.parseCommand(ViewCommand.COMMAND_WORD + " S1234567A") instanceof ViewCommand);
+    }
+
+    @Test
+    public void parseCommand_sort() throws Exception {
+        // Test parsing 'sort name'
+        SortCommand command = (SortCommand) parser.parseCommand(SortCommand.COMMAND_WORD + " name");
+        assertEquals(new SortCommand(SortCommand.SortType.NAME), command);
+
+        // Test parsing 'sort appointment'
+        command = (SortCommand) parser.parseCommand(SortCommand.COMMAND_WORD + " appointment");
+        assertEquals(new SortCommand(SortCommand.SortType.APPOINTMENT), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,2 +1,52 @@
-package seedu.address.logic.parser;public class SortCommandParserTest {
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class SortCommandParserTest {
+
+    private final SortCommandParser parser = new SortCommandParser();
+
+    @Test
+    public void parse_validArgsName_returnsSortCommand() throws Exception {
+        // Test valid sorting by name
+        SortCommand expectedCommand = new SortCommand(SortCommand.SortType.NAME);
+        SortCommand result = parser.parse("name");
+        assertEquals(expectedCommand, result);
+    }
+
+    @Test
+    public void parse_validArgsAppointment_returnsSortCommand() throws Exception {
+        // Test valid sorting by appointment
+        SortCommand expectedCommand = new SortCommand(SortCommand.SortType.APPOINTMENT);
+        SortCommand result = parser.parse("appointment");
+        assertEquals(expectedCommand, result);
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // Test invalid sorting argument
+        assertThrows(ParseException.class, () -> parser.parse("invalid"),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        // Test empty argument
+        assertThrows(ParseException.class, () -> parser.parse(""),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_whitespaceArgs_throwsParseException() {
+        // Test whitespace-only argument
+        assertThrows(ParseException.class, () -> parser.parse("   "),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.parser;public class SortCommandParserTest {
+}


### PR DESCRIPTION
Add SortCommand which allows the user to sort the list of patients either by name (lexicographical order) or by appointment (chronological order, with users having no appointments being placed at the bottom of the list (in natural order))